### PR TITLE
Update requirements.txt

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -26,3 +26,4 @@ setuptools>=39.2.0
 six>=1.12.0
 toml>=0.9
 sympy>=1.10.1
+symforce


### PR DESCRIPTION
Thank you for the wonderful software development.
I would like to politely request assistance in resolving the errors related to Symforce.

The following is before the countermeasure.
```
$ make px4_sitl_default
-- PX4 version: v1.15.0-alpha1-375-g6be8cbe439 (1.15.0)
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.10.12", minimum required is "3") 
-- PLATFORM posix
-- ROMFSROOT px4fmu_common
-- ROOTFSDIR .
-- TESTING y
-- ETHERNET y
-- PX4 config: px4_sitl_default
-- PX4 platform: posix
-- PX4 lockstep: enabled
-- The CXX compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- cmake build type: RelWithDebInfo
/usr/bin/python3: Error while finding module specification for 'symforce.symbolic' (ModuleNotFoundError: No module named 'symforce')
-- Could NOT find gz-transport (missing: gz-transport_DIR)
-- Could NOT find gz-transport (missing: gz-transport_DIR)
-- Could NOT find Java (missing: Java_JAVA_EXECUTABLE Java_JAR_EXECUTABLE Java_JAVAC_EXECUTABLE Java_JAVAH_EXECUTABLE Java_JAVADOC_EXECUTABLE) 
-- ROMFS: ROMFS/px4fmu_common
Architecture:  amd64
==> CPACK_INSTALL_PREFIX = @DEB_INSTALL_PREFIX@
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/work/hakoniwa-px4sim/px4/PX4-Autopilot/build/px4_sitl_default
[0/960] git submodule src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client
[1/960] git submodule src/drivers/gps/devices
[4/960] git submodule src/modules/mavlink/mavlink
[960/960] Linking CXX shared library src/examples/dyn_hello/examples__dyn_hello.px4mod
```

The following is after the countermeasure.
```
$  make px4_sitl_default
-- PX4 version: v1.15.0-alpha1-375-g6be8cbe439 (1.15.0)
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.10.12", minimum required is "3") 
-- PLATFORM posix
-- ROMFSROOT px4fmu_common
-- ROOTFSDIR .
-- TESTING y
-- ETHERNET y
-- PX4 config: px4_sitl_default
-- PX4 platform: posix
-- PX4 lockstep: enabled
-- The CXX compiler identification is GNU 11.4.0
-- The C compiler identification is GNU 11.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- cmake build type: RelWithDebInfo
-- Could NOT find gz-transport (missing: gz-transport_DIR)
-- Could NOT find gz-transport (missing: gz-transport_DIR)
-- Could NOT find Java (missing: Java_JAVA_EXECUTABLE Java_JAR_EXECUTABLE Java_JAVAC_EXECUTABLE Java_JAVAH_EXECUTABLE Java_JAVADOC_EXECUTABLE) 
-- ROMFS: ROMFS/px4fmu_common
Architecture:  amd64
==> CPACK_INSTALL_PREFIX = @DEB_INSTALL_PREFIX@
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/work/hakoniwa-px4sim/px4/PX4-Autopilot/build/px4_sitl_default
[0/960] git submodule src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client
[6/960] git submodule src/drivers/gps/devices
[10/960] git submodule src/modules/mavlink/mavlink
[960/960] Linking CXX shared library src/examples/dyn_hello/examples__dyn_hello.px4mod
```